### PR TITLE
Assign and reuse element key by child index

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,10 +110,12 @@ export function attributeListToReact (attributeList) {
   }, {})
 }
 
+let keyCounter = 0
+
 export function nodeListToReact (nodeList, createElement) {
-  return [...nodeList].reduce((accumulator, node, index) => {
+  return [...nodeList].reduce((accumulator, node) => {
     if (!node._domReactKey) {
-      node._domReactKey = String(index)
+      node._domReactKey = '_domReact' + String(keyCounter++)
     }
 
     const child = nodeToReact(node, createElement)

--- a/index.js
+++ b/index.js
@@ -111,7 +111,11 @@ export function attributeListToReact (attributeList) {
 }
 
 export function nodeListToReact (nodeList, createElement) {
-  return [...nodeList].reduce((accumulator, node) => {
+  return [...nodeList].reduce((accumulator, node, index) => {
+    if (!node._domReactKey) {
+      node._domReactKey = String(index)
+    }
+
     const child = nodeToReact(node, createElement)
 
     if (Array.isArray(child)) {
@@ -144,6 +148,10 @@ export function nodeToReact (node, createElement) {
 
   if (node.hasAttributes()) {
     props = attributeListToReact(node.attributes)
+  }
+
+  if (node._domReactKey) {
+    props.key = node._domReactKey
   }
 
   if (node.hasChildNodes()) {

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 import { describe, it } from 'mocha'
-import { equal, ok } from 'assert'
+import { equal, ok, deepEqual } from 'assert'
 import { JSDOM } from 'jsdom'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -115,14 +115,16 @@ describe('nodeToReact()', () => {
     it('should reuse assigned key for same elements reference', () => {
       document.body.innerHTML = '<ul><li>one</li><li>two</li></ul>'
       const list = document.body.firstChild
-      let elements = nodeListToReact(list.childNodes, createElement)
+      const before = nodeListToReact(list.childNodes, createElement)
 
       // Rearrange second list item before first
       list.insertBefore(list.lastChild, list.firstChild)
 
-      elements = nodeListToReact(list.childNodes, createElement)
-      assertKey(elements[0].key)
-      assertKey(elements[1].key)
+      const after = nodeListToReact(list.childNodes, createElement)
+      deepEqual(
+        before.map(({key}) => key),
+        after.map(({key}) => key).reverse()
+      )
     })
   })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -1,5 +1,5 @@
 import { describe, it } from 'mocha'
-import { equal } from 'assert'
+import { equal, ok } from 'assert'
 import { JSDOM } from 'jsdom'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
@@ -97,14 +97,19 @@ describe('nodeToReact()', () => {
   })
 
   describe('nodeListToReact', () => {
+    const rxKey = /^_domReact\d+$/
+    function assertKey (key) {
+      ok(rxKey.test(key), 'expected to match key pattern ' + rxKey.toString())
+    }
+
     it('should return array of React element with key assigned by child index', () => {
       document.body.innerHTML = '<p>test <span>test</span></p><strong>test</strong>'
       const elements = nodeListToReact(document.body.childNodes, createElement)
 
-      equal('0', elements[0].key)
+      assertKey(elements[0].key)
       equal('string', typeof elements[0].props.children[0])
-      equal('1', elements[0].props.children[1].key)
-      equal('1', elements[1].key)
+      assertKey(elements[0].props.children[1].key)
+      assertKey(elements[1].key)
     })
 
     it('should reuse assigned key for same elements reference', () => {
@@ -116,8 +121,8 @@ describe('nodeToReact()', () => {
       list.insertBefore(list.lastChild, list.firstChild)
 
       elements = nodeListToReact(list.childNodes, createElement)
-      equal('1', elements[0].key)
-      equal('0', elements[1].key)
+      assertKey(elements[0].key)
+      assertKey(elements[1].key)
     })
   })
 })

--- a/index.test.js
+++ b/index.test.js
@@ -4,7 +4,7 @@ import { JSDOM } from 'jsdom'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { nodeToReact } from '.'
+import { nodeToReact } from './index'
 
 const { window } = new JSDOM()
 const { document } = window

--- a/index.test.js
+++ b/index.test.js
@@ -4,7 +4,7 @@ import { JSDOM } from 'jsdom'
 import { createElement } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
-import { nodeToReact } from './index'
+import { nodeListToReact, nodeToReact } from './index'
 
 const { window } = new JSDOM()
 const { document } = window
@@ -94,5 +94,30 @@ describe('nodeToReact()', () => {
         return children
       }
     })))
+  })
+
+  describe('nodeListToReact', () => {
+    it('should return array of React element with key assigned by child index', () => {
+      document.body.innerHTML = '<p>test <span>test</span></p><strong>test</strong>'
+      const elements = nodeListToReact(document.body.childNodes, createElement)
+
+      equal('0', elements[0].key)
+      equal('string', typeof elements[0].props.children[0])
+      equal('1', elements[0].props.children[1].key)
+      equal('1', elements[1].key)
+    })
+
+    it('should reuse assigned key for same elements reference', () => {
+      document.body.innerHTML = '<ul><li>one</li><li>two</li></ul>'
+      const list = document.body.firstChild
+      let elements = nodeListToReact(list.childNodes, createElement)
+
+      // Rearrange second list item before first
+      list.insertBefore(list.lastChild, list.firstChild)
+
+      elements = nodeListToReact(list.childNodes, createElement)
+      equal('1', elements[0].key)
+      equal('0', elements[1].key)
+    })
   })
 })


### PR DESCRIPTION
This pull request assigns a key to avoid warnings when the array return value of `nodeListToReact` is rendered as children into a React element. It does so by assigning a key using the index of the child in its parent. Currently this behavior is only applied when using `nodeListToReact`, but `nodeToReact` could potentially emulate this by finding its own index within the parent. It also tries to reuse the key by assigning a private-ish property to the DOM node itself. This is in an effort to try to help React reconcile changes more easily, since after all, this is the purpose of the `key` prop in the first place.

See: https://facebook.github.io/react/docs/lists-and-keys.html#keys