### PR TITLE
Change the license from GPL3 to GPL2+

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "email": "ella@iseulde.com",
     "url": "https://iseulde.com"
   },
-  "license": "GPL-3.0",
+  "license": "GPL-2.0-or-later",
   "devDependencies": {
     "babel-cli": "6.x.x",
     "babel-plugin-transform-runtime": "6.x.x",


### PR DESCRIPTION
Per the discussion on https://github.com/WordPress/gutenberg/issues/6508, `dom-react`'s GPL3 license is incompatible with Gutenberg's GPL2+ license.

@iseulde, @aduth: As the people who've contributed to this repo, could you please review and approve this change?